### PR TITLE
Land Claim Kit

### DIFF
--- a/myprofile/BBP_Settings.json
+++ b/myprofile/BBP_Settings.json
@@ -3,7 +3,7 @@
     "g_BBPDisableCraftVanillaWatchtower": 1,
     "g_BBPRequireLandClaim": 1,
     "g_BBPLandClaimBlockDismantle": 1,
-    "g_BBPLandClaimRadius": 30,
+    "g_BBPLandClaimRadius": 60,
     "g_BBPAdminLandClaimRadius": 100,
     "g_BBPFloatingPlacement": 0,
     "g_BBPAdvanceRotation": 0,


### PR DESCRIPTION
I increased the distance of the land claim kit. I noticed, and it was brought up by the guys at the other base, they wanted to cover a larger area to account for their walls, but you can't put multiple land claim kits down if they overlap each other. So I though to rectify this we could increase the radius. It was set to 80 prior to moving to this map but I didn't want to make it too big.