### PR TITLE
Lower the number of bags in the world #410

### DIFF
--- a/mpmissions/empty.deerisle/db/types.xml
+++ b/mpmissions/empty.deerisle/db/types.xml
@@ -22544,8 +22544,7 @@
   </type>
   <type name="Sneakers_Gray">
     <nominal>10</nominal>
-<<<<<<< Updated upstream
-    <lifetime>2700</lifetime>
+    <lifetime>1800</lifetime>
     <restock>0</restock>
     <min>5</min>
     <quantmin>-1</quantmin>
@@ -22568,7 +22567,7 @@
   </type>
   <type name="Sneakers_Green">
     <nominal>10</nominal>
-    <lifetime>2700</lifetime>
+    <lifetime>1800</lifetime>
     <restock>0</restock>
     <min>5</min>
     <quantmin>-1</quantmin>
@@ -22591,7 +22590,7 @@
   </type>
   <type name="Sneakers_Red">
     <nominal>10</nominal>
-    <lifetime>2700</lifetime>
+    <lifetime>1800</lifetime>
     <restock>0</restock>
     <min>5</min>
     <quantmin>-1</quantmin>
@@ -22614,130 +22613,9 @@
   </type>
   <type name="Sneakers_White">
     <nominal>10</nominal>
-    <lifetime>2700</lifetime>
-    <restock>0</restock>
-    <min>5</min>
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="clothes" />
-    <tag name="floor" />
-    <usage name="Farm" />
-    <usage name="Village" />
-    <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier11" />
-    <value name="Tier8" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-  </type>
-  <type name="SodaCan_Cola">
-    <nominal>20</nominal>
-    <lifetime>2700</lifetime>
-    <restock>300</restock>
-    <min>10</min>
-=======
     <lifetime>1800</lifetime>
     <restock>0</restock>
     <min>5</min>
->>>>>>> Stashed changes
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="clothes" />
-    <tag name="floor" />
-    <usage name="Farm" />
-    <usage name="Village" />
-    <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier11" />
-    <value name="Tier8" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-  </type>
-<<<<<<< Updated upstream
-  <type name="SodaCan_Fronta">
-    <nominal>20</nominal>
-    <lifetime>2700</lifetime>
-    <restock>300</restock>
-    <min>10</min>
-=======
-  <type name="Sneakers_Green">
-    <nominal>10</nominal>
-    <lifetime>1800</lifetime>
-    <restock>0</restock>
-    <min>5</min>
->>>>>>> Stashed changes
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="clothes" />
-    <tag name="floor" />
-    <usage name="Farm" />
-    <usage name="Village" />
-    <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier11" />
-    <value name="Tier8" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-  </type>
-<<<<<<< Updated upstream
-  <type name="SodaCan_Kvass">
-    <nominal>20</nominal>
-    <lifetime>2700</lifetime>
-    <restock>300</restock>
-    <min>10</min>
-=======
-  <type name="Sneakers_Red">
-    <nominal>10</nominal>
-    <lifetime>1800</lifetime>
-    <restock>0</restock>
-    <min>5</min>
->>>>>>> Stashed changes
-    <quantmin>-1</quantmin>
-    <quantmax>-1</quantmax>
-    <cost>100</cost>
-    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="clothes" />
-    <tag name="floor" />
-    <usage name="Farm" />
-    <usage name="Village" />
-    <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier11" />
-    <value name="Tier8" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-  </type>
-<<<<<<< Updated upstream
-  <type name="SodaCan_Pipsi">
-    <nominal>20</nominal>
-    <lifetime>2700</lifetime>
-    <restock>300</restock>
-    <min>10</min>
-=======
-  <type name="Sneakers_White">
-    <nominal>10</nominal>
-    <lifetime>1800</lifetime>
-    <restock>0</restock>
-    <min>5</min>
->>>>>>> Stashed changes
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>

--- a/mpmissions/empty.deerisle/db/types.xml
+++ b/mpmissions/empty.deerisle/db/types.xml
@@ -694,10 +694,10 @@
     <value name="Tier2" />
   </type>
   <type name="AliceBag_Black">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>1800</restock>
-    <min>5</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -714,10 +714,10 @@
     <value name="Tier2" />
   </type>
   <type name="AliceBag_Camo">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>1800</restock>
-    <min>5</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -734,10 +734,10 @@
     <value name="Tier2" />
   </type>
   <type name="AliceBag_Green">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>1800</restock>
-    <min>5</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -764,20 +764,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="1" />
     <category name="containers" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_00buck_10rnd">
     <nominal>60</nominal>
@@ -794,20 +780,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_12gaRubberSlug_10Rnd">
     <nominal>30</nominal>
@@ -847,20 +819,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_22_50Rnd">
     <nominal>30</nominal>
@@ -903,20 +861,6 @@
     <usage name="Police" />
     <usage name="Hunting" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_308Win_20Rnd">
     <nominal>60</nominal>
@@ -932,20 +876,6 @@
     <usage name="Police" />
     <usage name="Hunting" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_357_20Rnd">
     <nominal>40</nominal>
@@ -964,20 +894,6 @@
     <usage name="Village" />
     <usage name="Hunting" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_380_35rnd">
     <nominal>40</nominal>
@@ -992,20 +908,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_45ACP_25rnd">
     <nominal>40</nominal>
@@ -1020,20 +922,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_545x39Tracer_20Rnd">
     <nominal>60</nominal>
@@ -1049,20 +937,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_545x39_20Rnd">
     <nominal>60</nominal>
@@ -1078,20 +952,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_556x45Tracer_20Rnd">
     <nominal>60</nominal>
@@ -1107,20 +967,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_556x45_20Rnd">
     <nominal>60</nominal>
@@ -1136,20 +982,6 @@
     <usage name="Police" />
     <usage name="Prison" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_762x39Tracer_20Rnd">
     <nominal>60</nominal>
@@ -1165,20 +997,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_762x39_20Rnd">
     <nominal>60</nominal>
@@ -1193,20 +1011,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_762x54Tracer_20Rnd">
     <nominal>60</nominal>
@@ -1222,20 +1026,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_762x54_20Rnd">
     <nominal>60</nominal>
@@ -1250,20 +1040,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_9x19_25rnd">
     <nominal>40</nominal>
@@ -1279,20 +1055,6 @@
     <usage name="Police" />
     <usage name="Prison" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_9x39AP_20Rnd">
     <nominal>30</nominal>
@@ -1307,20 +1069,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="AmmoBox_9x39_20Rnd">
     <nominal>30</nominal>
@@ -1335,20 +1083,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_12gaPellets">
     <nominal>60</nominal>
@@ -1363,20 +1097,6 @@
     <usage name="Police" />
     <usage name="Farm" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_12gaRubberSlug">
     <nominal>30</nominal>
@@ -1465,20 +1185,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_308WinTracer">
     <nominal>60</nominal>
@@ -1492,20 +1198,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_357">
     <nominal>35</nominal>
@@ -1524,20 +1216,6 @@
     <usage name="Hunting" />
     <usage name="Coast" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_380">
     <nominal>50</nominal>
@@ -1555,20 +1233,6 @@
     <usage name="Hunting" />
     <usage name="Coast" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_45ACP">
     <nominal>30</nominal>
@@ -1582,20 +1246,6 @@
     <category name="weapons" />
     <usage name="Military" />
     <usage name="Police" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_545x39">
     <nominal>30</nominal>
@@ -1609,20 +1259,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_545x39Tracer">
     <nominal>20</nominal>
@@ -1636,20 +1272,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_556x45">
     <nominal>60</nominal>
@@ -1663,20 +1285,6 @@
     <category name="weapons" />
     <usage name="Military" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_556x45Tracer">
     <nominal>60</nominal>
@@ -1690,20 +1298,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_762x39">
     <nominal>60</nominal>
@@ -1718,20 +1312,6 @@
     <tag name="shelves" />
     <usage name="Military" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_762x39Tracer">
     <nominal>60</nominal>
@@ -1745,20 +1325,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_762x54">
     <nominal>60</nominal>
@@ -1775,20 +1341,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_762x54Tracer">
     <nominal>60</nominal>
@@ -1802,20 +1354,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_9x19">
     <nominal>60</nominal>
@@ -1831,20 +1369,6 @@
     <usage name="Prison" />
     <usage name="Village" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_9x39">
     <nominal>20</nominal>
@@ -1858,20 +1382,6 @@
     <category name="weapons" />
     <usage name="Military" />
     <usage name="Police" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_9x39AP">
     <nominal>20</nominal>
@@ -1885,20 +1395,6 @@
     <category name="weapons" />
     <usage name="Military" />
     <usage name="Police" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_Flare">
     <nominal>20</nominal>
@@ -1913,20 +1409,6 @@
     <usage name="Police" />
     <usage name="Coast" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_FlareBlue">
     <nominal>20</nominal>
@@ -1939,20 +1421,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_FlareGreen">
     <nominal>20</nominal>
@@ -1965,20 +1433,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ammo_FlareRed">
     <nominal>20</nominal>
@@ -1991,20 +1445,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Animal_BosTaurusF_Brown">
     <nominal>10</nominal>
@@ -2647,10 +2087,10 @@
     <value name="Tier2" />
   </type>
   <type name="AssaultBag_Black">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>4</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -2667,10 +2107,10 @@
     <value name="Tier2" />
   </type>
   <type name="AssaultBag_Green">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>4</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -2687,10 +2127,10 @@
     <value name="Tier2" />
   </type>
   <type name="AssaultBag_Ttsko">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>4</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -3025,20 +2465,6 @@
     <tag name="shelves" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BakedBeansCan_Opened">
     <nominal>0</nominal>
@@ -3423,20 +2849,6 @@
     <usage name="Prison" />
     <usage name="Hunting" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BandanaMask_BlackPattern">
     <nominal>0</nominal>
@@ -4146,20 +3558,6 @@
     <usage name="School" />
     <usage name="Prison" />
     <usage name="Lunapark" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BatteryCharger">
     <nominal>20</nominal>
@@ -4956,20 +4354,6 @@
     <usage name="Village" />
     <usage name="Town" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BoonieHat_Blue">
     <nominal>20</nominal>
@@ -5106,20 +4490,6 @@
     <usage name="Village" />
     <usage name="Town" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BoonieHat_Orange">
     <nominal>20</nominal>
@@ -5206,20 +4576,6 @@
     <tag name="shelves" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BrassKnuckles_Dull">
     <nominal>10</nominal>
@@ -5583,20 +4939,6 @@
     <usage name="Hunting" />
     <usage name="Coast" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="BurlapSackCover">
     <nominal>0</nominal>
@@ -6300,20 +5642,6 @@
     <usage name="Hunting" />
     <usage name="Town" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CargoPants_Blue">
     <nominal>20</nominal>
@@ -6354,20 +5682,6 @@
     <usage name="Hunting" />
     <usage name="Town" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CargoPants_Grey">
     <nominal>20</nominal>
@@ -6426,20 +5740,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Chemlight_Blue">
     <nominal>40</nominal>
@@ -6454,20 +5754,6 @@
     <usage name="Police" />
     <usage name="Coast" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Chemlight_Green">
     <nominal>40</nominal>
@@ -6487,20 +5773,6 @@
     <usage name="Coast" />
     <usage name="Town" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Chemlight_Red">
     <nominal>30</nominal>
@@ -6513,20 +5785,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Chemlight_White">
     <nominal>40</nominal>
@@ -6543,20 +5801,6 @@
     <usage name="Hunting" />
     <usage name="Coast" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Chemlight_Yellow">
     <nominal>40</nominal>
@@ -6570,20 +5814,6 @@
     <category name="tools" />
     <usage name="Military" />
     <usage name="Police" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ChernarusMap">
     <nominal>10</nominal>
@@ -6688,10 +5918,10 @@
     <value name="Tier2" />
   </type>
   <type name="ChildBag_Blue">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -6710,10 +5940,10 @@
     <value name="Tier2" />
   </type>
   <type name="ChildBag_Green">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -6732,10 +5962,10 @@
     <value name="Tier2" />
   </type>
   <type name="ChildBag_Red">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -7698,20 +6928,6 @@
     <category name="clothes" />
     <tag name="floor" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CombatBoots_Black">
     <nominal>10</nominal>
@@ -7725,20 +6941,6 @@
     <category name="clothes" />
     <tag name="floor" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CombatBoots_Brown">
     <nominal>10</nominal>
@@ -7752,20 +6954,6 @@
     <category name="clothes" />
     <tag name="floor" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CombatBoots_Green">
     <nominal>10</nominal>
@@ -7779,20 +6967,6 @@
     <category name="clothes" />
     <tag name="floor" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CombatBoots_Grey">
     <nominal>10</nominal>
@@ -7806,20 +6980,6 @@
     <category name="clothes" />
     <tag name="floor" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CombatKnife">
     <nominal>20</nominal>
@@ -7833,20 +6993,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="CombinationLock">
     <nominal>40</nominal>
@@ -8190,10 +7336,10 @@
     <value name="Tier2" />
   </type>
   <type name="CoyoteBag_Brown">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>1800</restock>
-    <min>5</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -8210,10 +7356,10 @@
     <value name="Tier2" />
   </type>
   <type name="CoyoteBag_Green">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>1800</restock>
-    <min>5</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -8567,20 +7713,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="1" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="DirtBikeHelmet_Black">
     <nominal>10</nominal>
@@ -8792,20 +7924,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="DisinfectantSpray">
     <nominal>50</nominal>
@@ -8819,20 +7937,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="DogFoodCan">
     <nominal>20</nominal>
@@ -8993,10 +8097,10 @@
     <value name="Tier2" />
   </type>
   <type name="DryBag_Black">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -9004,26 +8108,12 @@
     <category name="containers" />
     <usage name="Coast" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="DryBag_Blue">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -9041,10 +8131,10 @@
     <value name="Tier2" />
   </type>
   <type name="DryBag_Green">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -9062,10 +8152,10 @@
     <value name="Tier2" />
   </type>
   <type name="DryBag_Orange">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -9083,10 +8173,10 @@
     <value name="Tier2" />
   </type>
   <type name="DryBag_Red">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -9104,10 +8194,10 @@
     <value name="Tier2" />
   </type>
   <type name="DryBag_Yellow">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -9141,20 +8231,6 @@
     <usage name="Coast" />
     <usage name="Town" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="EasterEgg">
     <nominal>5</nominal>
@@ -9168,20 +8244,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ElectronicRepairKit">
     <nominal>20</nominal>
@@ -9195,20 +8257,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="EngineOil">
     <nominal>0</nominal>
@@ -9265,20 +8313,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="EpoxyPutty">
     <nominal>100</nominal>
@@ -9292,20 +8326,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Fabric">
     <nominal>20</nominal>
@@ -9521,20 +8541,6 @@
     <category name="tools" />
     <tag name="floor" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefighterAxe_Black">
     <nominal>0</nominal>
@@ -9548,20 +8554,6 @@
     <category name="tools" />
     <tag name="floor" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefighterAxe_Green">
     <nominal>0</nominal>
@@ -9575,20 +8567,6 @@
     <category name="tools" />
     <tag name="floor" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefighterJacket_Beige">
     <nominal>10</nominal>
@@ -9601,20 +8579,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefighterJacket_Black">
     <nominal>10</nominal>
@@ -9627,20 +8591,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefightersHelmet_Red">
     <nominal>8</nominal>
@@ -9653,20 +8603,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefightersHelmet_White">
     <nominal>8</nominal>
@@ -9679,20 +8615,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefightersHelmet_Yellow">
     <nominal>8</nominal>
@@ -9705,20 +8627,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefightersPants_Beige">
     <nominal>10</nominal>
@@ -9731,20 +8639,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FirefightersPants_Black">
     <nominal>10</nominal>
@@ -9757,20 +8651,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Firefighter" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Fireplace">
     <nominal>0</nominal>
@@ -9839,20 +8719,6 @@
     <category name="containers" />
     <tag name="shelves" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FishingRod">
     <nominal>40</nominal>
@@ -10500,20 +9366,6 @@
     <usage name="Police" />
     <usage name="Coast" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="FlashGrenade">
     <nominal>40</nominal>
@@ -10528,20 +9380,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Flashlight">
     <nominal>40</nominal>
@@ -10938,20 +9776,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieAtt_Tan">
     <nominal>10</nominal>
@@ -10964,20 +9788,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieAtt_Woodland">
     <nominal>10</nominal>
@@ -10990,20 +9800,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieBushrag_Mossy">
     <nominal>10</nominal>
@@ -11016,20 +9812,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieBushrag_Tan">
     <nominal>10</nominal>
@@ -11042,20 +9824,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieBushrag_Woodland">
     <nominal>10</nominal>
@@ -11068,20 +9836,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieHood_Mossy">
     <nominal>10</nominal>
@@ -11094,20 +9848,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieHood_Tan">
     <nominal>10</nominal>
@@ -11120,20 +9860,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieHood_Woodland">
     <nominal>10</nominal>
@@ -11146,20 +9872,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieSuit_Mossy">
     <nominal>10</nominal>
@@ -11172,20 +9884,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieSuit_Tan">
     <nominal>10</nominal>
@@ -11198,20 +9896,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieSuit_Woodland">
     <nominal>10</nominal>
@@ -11224,20 +9908,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieTop_Mossy">
     <nominal>10</nominal>
@@ -11250,20 +9920,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieTop_Tan">
     <nominal>10</nominal>
@@ -11276,20 +9932,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GhillieTop_Woodland">
     <nominal>10</nominal>
@@ -11302,20 +9944,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="GiftBox_Large_1">
     <nominal>0</nominal>
@@ -11913,20 +10541,6 @@
     <category name="tools" />
     <usage name="Industrial" />
     <usage name="Farm" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Hammer">
     <nominal>80</nominal>
@@ -11941,20 +10555,6 @@
     <usage name="Industrial" />
     <usage name="Farm" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="HandDrillKit">
     <nominal>0</nominal>
@@ -11987,20 +10587,6 @@
     <category name="tools" />
     <usage name="Industrial" />
     <usage name="Farm" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="HandcuffKeys">
     <nominal>20</nominal>
@@ -12037,20 +10623,6 @@
     <tag name="shelves" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="HandcuffsLocked">
     <nominal>0</nominal>
@@ -13480,20 +12052,6 @@
     <tag name="floor" />
     <usage name="Farm" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="HeadlightH7">
     <nominal>0</nominal>
@@ -13615,20 +12173,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="HighCapacityVest_Black">
     <nominal>10</nominal>
@@ -14356,10 +12900,10 @@
     <value name="Tier2" />
   </type>
   <type name="HuntingBag">
-    <nominal>30</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>20</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -14634,20 +13178,6 @@
     <usage name="Town" />
     <usage name="Firefighter" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Izh43Shotgun">
     <nominal>20</nominal>
@@ -15346,20 +13876,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="LactariusMushroom">
     <nominal>0</nominal>
@@ -15544,20 +14060,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="LeatherBelt_Beige">
     <nominal>0</nominal>
@@ -16047,20 +14549,6 @@
     <tag name="shelves" />
     <usage name="Industrial" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="LeatherShirt_Natural">
     <nominal>0</nominal>
@@ -16244,20 +14732,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="LongWoodenStick">
     <nominal>0</nominal>
@@ -16331,20 +14805,6 @@
     <usage name="Town" />
     <usage name="Office" />
     <usage name="School" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Lunchmeat_Opened">
     <nominal>0</nominal>
@@ -16376,20 +14836,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M18SmokeGrenade_Purple">
     <nominal>30</nominal>
@@ -16402,20 +14848,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M18SmokeGrenade_Red">
     <nominal>30</nominal>
@@ -16428,20 +14860,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M18SmokeGrenade_White">
     <nominal>30</nominal>
@@ -16454,20 +14872,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M18SmokeGrenade_Yellow">
     <nominal>30</nominal>
@@ -16480,20 +14884,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M16A2">
     <nominal>10</nominal>
@@ -16765,20 +15155,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M4_T3NRDSOptic">
     <nominal>10</nominal>
@@ -16899,20 +15275,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="M68Optic">
     <nominal>12</nominal>
@@ -17167,20 +15529,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_AK101_30Rnd">
     <nominal>20</nominal>
@@ -17193,20 +15541,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_AK74_30Rnd">
     <nominal>40</nominal>
@@ -17219,20 +15553,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_AKM_30Rnd">
     <nominal>20</nominal>
@@ -17245,20 +15565,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="weapons" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_AKM_Drum75Rnd">
     <nominal>12</nominal>
@@ -17272,20 +15578,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_AKM_Palm30Rnd">
     <nominal>20</nominal>
@@ -17299,20 +15591,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_CMAG_10Rnd">
     <nominal>20</nominal>
@@ -17326,20 +15604,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_CMAG_20Rnd">
     <nominal>20</nominal>
@@ -17353,20 +15617,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_CMAG_30Rnd">
     <nominal>20</nominal>
@@ -17380,20 +15630,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_CMAG_40Rnd">
     <nominal>20</nominal>
@@ -17407,20 +15643,6 @@
     <category name="weapons" />
     <tag name="shelves" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mag_CZ527_5rnd">
     <nominal>20</nominal>
@@ -18249,20 +16471,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsHat_Green">
     <nominal>10</nominal>
@@ -18275,20 +16483,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsHat_White">
     <nominal>10</nominal>
@@ -18301,20 +16495,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsPants_Blue">
     <nominal>10</nominal>
@@ -18327,20 +16507,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsPants_Green">
     <nominal>10</nominal>
@@ -18353,20 +16519,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsPants_White">
     <nominal>10</nominal>
@@ -18379,20 +16531,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsShirt_Blue">
     <nominal>10</nominal>
@@ -18405,20 +16543,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsShirt_Green">
     <nominal>10</nominal>
@@ -18431,20 +16555,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MedicalScrubsShirt_White">
     <nominal>10</nominal>
@@ -18457,20 +16567,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MediumGasCanister">
     <nominal>30</nominal>
@@ -18502,7 +16598,7 @@
     <quantmax>-1</quantmax>
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="tools" />
+    <category name="containers" />
     <usage name="Hunting" />
     <usage name="Coast" />
     <value name="Tier15" />
@@ -18639,20 +16735,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MilitaryBelt">
     <nominal>20</nominal>
@@ -18665,20 +16747,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="MilitaryBeret_CDF">
     <nominal>10</nominal>
@@ -19071,20 +17139,6 @@
     <tag name="shelves" />
     <usage name="Firefighter" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Mosin9130">
     <nominal>10</nominal>
@@ -19361,10 +17415,10 @@
     <value name="Tier2" />
   </type>
   <type name="MountainBag_Blue">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -19383,10 +17437,10 @@
     <value name="Tier2" />
   </type>
   <type name="MountainBag_Green">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -19405,10 +17459,10 @@
     <value name="Tier2" />
   </type>
   <type name="MountainBag_Orange">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -19427,10 +17481,10 @@
     <value name="Tier2" />
   </type>
   <type name="MountainBag_Red">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -20141,20 +18195,6 @@
     <tag name="shelves" />
     <usage name="Military" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PipeWrench">
     <nominal>30</nominal>
@@ -20274,20 +18314,6 @@
     <tag name="shelves" />
     <usage name="Coast" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Pajka">
     <nominal>25</nominal>
@@ -20361,20 +18387,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ParamedicJacket_Crimson">
     <nominal>10</nominal>
@@ -20387,20 +18399,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ParamedicJacket_Green">
     <nominal>10</nominal>
@@ -20413,20 +18411,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ParamedicPants_Blue">
     <nominal>10</nominal>
@@ -20439,20 +18423,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ParamedicPants_Crimson">
     <nominal>10</nominal>
@@ -20465,20 +18435,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ParamedicPants_Green">
     <nominal>10</nominal>
@@ -20491,20 +18447,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Pate">
     <nominal>50</nominal>
@@ -20521,20 +18463,6 @@
     <usage name="Village" />
     <usage name="Office" />
     <usage name="School" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Pate_Opened">
     <nominal>0</nominal>
@@ -20568,20 +18496,6 @@
     <tag name="shelves" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PeachesCan_Opened">
     <nominal>0</nominal>
@@ -20780,20 +18694,6 @@
     <tag name="shelves" />
     <usage name="Industrial" />
     <usage name="Farm" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PigPelt">
     <nominal>0</nominal>
@@ -20906,20 +18806,6 @@
     <category name="weapons" />
     <usage name="Military" />
     <usage name="Police" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PlantMaterial">
     <nominal>0</nominal>
@@ -21130,20 +19016,6 @@
     <usage name="Industrial" />
     <usage name="Farm" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Plum">
     <nominal>0</nominal>
@@ -21177,20 +19049,6 @@
     <tag name="shelves" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PoliceJacket">
     <nominal>30</nominal>
@@ -21204,20 +19062,6 @@
     <category name="clothes" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PoliceJacketOrel">
     <nominal>16</nominal>
@@ -21231,20 +19075,6 @@
     <category name="clothes" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PolicePants">
     <nominal>30</nominal>
@@ -21258,20 +19088,6 @@
     <category name="clothes" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PolicePantsOrel">
     <nominal>16</nominal>
@@ -21285,20 +19101,6 @@
     <category name="clothes" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PoliceVest">
     <nominal>40</nominal>
@@ -21312,20 +19114,6 @@
     <category name="clothes" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PorkCan">
     <nominal>50</nominal>
@@ -21342,20 +19130,6 @@
     <usage name="Village" />
     <usage name="Office" />
     <usage name="School" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="PorkCan_Opened">
     <nominal>0</nominal>
@@ -21730,20 +19504,6 @@
     <usage name="Coast" />
     <usage name="Firefighter" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="QuiltedJacket_Black">
     <nominal>20</nominal>
@@ -21974,20 +19734,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="explosives" />
     <usage name="Military" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="RadarCap_Black">
     <nominal>10</nominal>
@@ -22451,20 +20197,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ruger1022">
     <nominal>30</nominal>
@@ -22611,20 +20343,6 @@
     <usage name="Firefighter" />
     <usage name="Medic" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SalineBagIV">
     <nominal>0</nominal>
@@ -22743,20 +20461,6 @@
     <tag name="shelves" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SardinesCan_Opened">
     <nominal>0</nominal>
@@ -22904,20 +20608,6 @@
     <usage name="Industrial" />
     <usage name="Farm" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Scout">
     <nominal>5</nominal>
@@ -22992,20 +20682,6 @@
     <usage name="Industrial" />
     <usage name="Farm" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Sedan_02">
     <nominal>0</nominal>
@@ -23868,20 +21544,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Village" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SharpLongWoodenStick">
     <nominal>0</nominal>
@@ -24319,20 +21981,6 @@
     <usage name="Farm" />
     <usage name="Village" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Sickle">
     <nominal>10</nominal>
@@ -24728,20 +22376,6 @@
     <category name="tools" />
     <tag name="floor" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SlicedPumpkin">
     <nominal>0</nominal>
@@ -24846,10 +22480,10 @@
     <value name="Tier2" />
   </type>
   <type name="SmershBag">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>6</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -24910,6 +22544,7 @@
   </type>
   <type name="Sneakers_Gray">
     <nominal>10</nominal>
+<<<<<<< Updated upstream
     <lifetime>2700</lifetime>
     <restock>0</restock>
     <min>5</min>
@@ -25005,85 +22640,125 @@
     <lifetime>2700</lifetime>
     <restock>300</restock>
     <min>10</min>
+=======
+    <lifetime>1800</lifetime>
+    <restock>0</restock>
+    <min>5</min>
+>>>>>>> Stashed changes
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="industrialfood" />
+    <category name="clothes" />
+    <tag name="floor" />
+    <usage name="Farm" />
     <usage name="Village" />
     <usage name="Town" />
     <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
     <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
     <value name="Tier8" />
-    <value name="Tier7" />
     <value name="Tier6" />
     <value name="Tier5" />
     <value name="Tier4" />
     <value name="Tier3" />
     <value name="Tier2" />
-    <value name="Tier1" />
   </type>
+<<<<<<< Updated upstream
   <type name="SodaCan_Fronta">
     <nominal>20</nominal>
     <lifetime>2700</lifetime>
     <restock>300</restock>
     <min>10</min>
+=======
+  <type name="Sneakers_Green">
+    <nominal>10</nominal>
+    <lifetime>1800</lifetime>
+    <restock>0</restock>
+    <min>5</min>
+>>>>>>> Stashed changes
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="industrialfood" />
+    <category name="clothes" />
+    <tag name="floor" />
+    <usage name="Farm" />
     <usage name="Village" />
     <usage name="Town" />
     <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
     <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
     <value name="Tier8" />
-    <value name="Tier7" />
     <value name="Tier6" />
     <value name="Tier5" />
     <value name="Tier4" />
     <value name="Tier3" />
     <value name="Tier2" />
-    <value name="Tier1" />
   </type>
+<<<<<<< Updated upstream
   <type name="SodaCan_Kvass">
     <nominal>20</nominal>
     <lifetime>2700</lifetime>
     <restock>300</restock>
     <min>10</min>
+=======
+  <type name="Sneakers_Red">
+    <nominal>10</nominal>
+    <lifetime>1800</lifetime>
+    <restock>0</restock>
+    <min>5</min>
+>>>>>>> Stashed changes
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
-    <category name="industrialfood" />
+    <category name="clothes" />
+    <tag name="floor" />
+    <usage name="Farm" />
     <usage name="Village" />
     <usage name="Town" />
     <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
     <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
     <value name="Tier8" />
-    <value name="Tier7" />
     <value name="Tier6" />
     <value name="Tier5" />
     <value name="Tier4" />
     <value name="Tier3" />
     <value name="Tier2" />
-    <value name="Tier1" />
   </type>
+<<<<<<< Updated upstream
   <type name="SodaCan_Pipsi">
     <nominal>20</nominal>
     <lifetime>2700</lifetime>
+    <restock>300</restock>
+    <min>10</min>
+=======
+  <type name="Sneakers_White">
+    <nominal>10</nominal>
+    <lifetime>1800</lifetime>
+    <restock>0</restock>
+    <min>5</min>
+>>>>>>> Stashed changes
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
+    <category name="clothes" />
+    <tag name="floor" />
+    <usage name="Farm" />
+    <usage name="Village" />
+    <usage name="Town" />
+    <value name="Tier15" />
+    <value name="Tier11" />
+    <value name="Tier8" />
+    <value name="Tier6" />
+    <value name="Tier5" />
+    <value name="Tier4" />
+    <value name="Tier3" />
+    <value name="Tier2" />
+  </type>
+  <type name="SodaCan_Cola">
+    <nominal>20</nominal>
+    <lifetime>1800</lifetime>
     <restock>300</restock>
     <min>10</min>
     <quantmin>-1</quantmin>
@@ -25093,20 +22768,45 @@
     <category name="industrialfood" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
+  </type>
+  <type name="SodaCan_Fronta">
+    <nominal>20</nominal>
+    <lifetime>1800</lifetime>
+    <restock>300</restock>
+    <min>10</min>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
+    <category name="industrialfood" />
+    <usage name="Village" />
+    <usage name="Town" />
+  </type>
+  <type name="SodaCan_Kvass">
+    <nominal>20</nominal>
+    <lifetime>1800</lifetime>
+    <restock>300</restock>
+    <min>10</min>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
+    <category name="industrialfood" />
+    <usage name="Village" />
+    <usage name="Town" />
+  </type>
+  <type name="SodaCan_Pipsi">
+    <nominal>20</nominal>
+    <lifetime>1800</lifetime>
+    <restock>300</restock>
+    <min>10</min>
+    <quantmin>-1</quantmin>
+    <quantmax>-1</quantmax>
+    <cost>100</cost>
+    <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
+    <category name="industrialfood" />
+    <usage name="Village" />
+    <usage name="Town" />
   </type>
   <type name="SodaCan_Spite">
     <nominal>20</nominal>
@@ -25120,20 +22820,6 @@
     <category name="industrialfood" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SpaghettiCan">
     <nominal>20</nominal>
@@ -25148,20 +22834,6 @@
     <tag name="shelves" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SpaghettiCan_Opened">
     <nominal>0</nominal>
@@ -25363,20 +23035,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Ssh68Helmet">
     <nominal>20</nominal>
@@ -25410,20 +23068,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SteakKnife">
     <nominal>20</nominal>
@@ -25502,20 +23146,6 @@
     <category name="tools" />
     <usage name="Police" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SurgicalGloves_Blue">
     <nominal>10</nominal>
@@ -25528,20 +23158,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SurgicalGloves_Green">
     <nominal>10</nominal>
@@ -25554,20 +23170,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SurgicalGloves_LightBlue">
     <nominal>10</nominal>
@@ -25580,20 +23182,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SurgicalGloves_White">
     <nominal>10</nominal>
@@ -25606,20 +23194,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="SurgicalMask">
     <nominal>10</nominal>
@@ -25632,20 +23206,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="clothes" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Sweater_Blue">
     <nominal>20</nominal>
@@ -26027,20 +23587,6 @@
     <usage name="Village" />
     <usage name="Coast" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="TacticalBaconCan_Opened">
     <nominal>0</nominal>
@@ -26226,10 +23772,10 @@
     <value name="Tier2" />
   </type>
   <type name="TaloonBag_Blue">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -26248,10 +23794,10 @@
     <value name="Tier2" />
   </type>
   <type name="TaloonBag_Green">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -26270,10 +23816,10 @@
     <value name="Tier2" />
   </type>
   <type name="TaloonBag_Orange">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -26292,10 +23838,10 @@
     <value name="Tier2" />
   </type>
   <type name="TaloonBag_Violet">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -26425,20 +23971,6 @@
     <usage name="Coast" />
     <usage name="Firefighter" />
     <usage name="Medic" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Thermometer">
     <nominal>10</nominal>
@@ -26515,20 +24047,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Tomato">
     <nominal>40</nominal>
@@ -26612,10 +24130,10 @@
     <value name="Tier2" />
   </type>
   <type name="TortillaBag">
-    <nominal>10</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>1800</restock>
-    <min>4</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -26885,20 +24403,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Truck_01_Door_1_1_BlueRust">
     <nominal>4</nominal>
@@ -27423,20 +24927,6 @@
     <tag name="shelves" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="TunaCan_Opened">
     <nominal>0</nominal>
@@ -27670,20 +25160,6 @@
     <tag name="shelves" />
     <usage name="Military" />
     <usage name="Police" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="UnknownFoodCan">
     <nominal>20</nominal>
@@ -27700,20 +25176,6 @@
     <usage name="Village" />
     <usage name="Office" />
     <usage name="Prison" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="UnknownFoodCan_Opened">
     <nominal>0</nominal>
@@ -27828,20 +25290,6 @@
     <tag name="shelves" />
     <usage name="Medic" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="Watchtower">
     <nominal>0</nominal>
@@ -27892,52 +25340,24 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <usage name="Village" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="WaterproofBag_Green">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="containers" />
     <usage name="Coast" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="WaterproofBag_Orange">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -27954,10 +25374,10 @@
     <value name="Tier2" />
   </type>
   <type name="WaterproofBag_Yellow">
-    <nominal>20</nominal>
+    <nominal>5</nominal>
     <lifetime>21600</lifetime>
     <restock>0</restock>
-    <min>10</min>
+    <min>3</min>
     <quantmin>-1</quantmin>
     <quantmax>-1</quantmax>
     <cost>100</cost>
@@ -27986,20 +25406,6 @@
     <usage name="Military" />
     <usage name="Police" />
     <usage name="Hunting" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="WeldingMask">
     <nominal>10</nominal>
@@ -28121,20 +25527,6 @@
     <category name="tools" />
     <tag name="shelves" />
     <usage name="Farm" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="WildboarPelt">
     <nominal>0</nominal>
@@ -28482,20 +25874,6 @@
     <usage name="Village" />
     <usage name="Coast" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="WoodenCrate">
     <nominal>0</nominal>
@@ -29029,20 +26407,6 @@
     <flags count_in_cargo="0" count_in_hoarder="0" count_in_map="1" count_in_player="0" crafted="0" deloot="0" />
     <category name="tools" />
     <usage name="Industrial" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="XmasLights">
     <nominal>30</nominal>
@@ -29081,20 +26445,6 @@
     <usage name="Office" />
     <usage name="School" />
     <usage name="Lunapark" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ZagorkyChocolate">
     <nominal>40</nominal>
@@ -29112,20 +26462,6 @@
     <usage name="Hunting" />
     <usage name="Coast" />
     <usage name="Town" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ZagorkyPeanuts">
     <nominal>40</nominal>
@@ -29142,20 +26478,6 @@
     <usage name="Office" />
     <usage name="School" />
     <usage name="Lunapark" />
-    <value name="Tier15" />
-    <value name="Tier13" />
-    <value name="Tier12" />
-    <value name="Tier11" />
-    <value name="Tier10" />
-    <value name="Tier9" />
-    <value name="Tier8" />
-    <value name="Tier7" />
-    <value name="Tier6" />
-    <value name="Tier5" />
-    <value name="Tier4" />
-    <value name="Tier3" />
-    <value name="Tier2" />
-    <value name="Tier1" />
   </type>
   <type name="ZSh3PilotHelmet">
     <nominal>20</nominal>
@@ -31024,10 +28346,10 @@
         <value name="Tier2" />
     </type>
     <type name="MassBlackYellowMB">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31045,10 +28367,10 @@
         <value name="Tier2" />
     </type>
     <type name="Massczech">
-        <nominal>30</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>10</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31187,10 +28509,10 @@
         <value name="Tier2" />
     </type>
     <type name="MasscamoTaloon">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31227,10 +28549,10 @@
         <value name="Tier2" />
     </type>
     <type name="Massbrownhuntingbp">
-        <nominal>20</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>10</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31412,10 +28734,10 @@
         <value name="Tier2" />
     </type>
     <type name="MassSmersh">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31736,10 +29058,10 @@
         <value name="Tier2" />
     </type>
     <type name="MassWinterTortilla">
-        <nominal>20</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>10</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31816,10 +29138,10 @@
         <value name="Tier2" />
     </type>
     <type name="MassWinterHuntingbp">
-        <nominal>20</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>10</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31916,10 +29238,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassczechWinter">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31937,10 +29259,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassCoyoteBPUrban">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31957,10 +29279,10 @@
         <value name="Tier2" />
     </type>
 	<type name="Massblackhuntingbp">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -31977,10 +29299,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassCanvasBag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -32309,10 +29631,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MasscamoTaloon1">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33404,10 +30726,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSmershblack">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33458,10 +30780,10 @@
         <value name="Tier1" />
     </type>
 	<type name="Massbag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33479,10 +30801,10 @@
         <value name="Tier2" />
     </type>
 	<type name="Massbag2">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33500,10 +30822,10 @@
         <value name="Tier2" />
     </type>
 	<type name="Massbag3">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33521,10 +30843,10 @@
         <value name="Tier2" />
     </type>
 	<type name="Massbag4">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33605,7 +30927,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33626,7 +30948,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33647,7 +30969,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33665,10 +30987,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassNBC_Bag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>6</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33854,10 +31176,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassMolleBagBlack">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33874,10 +31196,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassMolleBagDesert">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -33894,10 +31216,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassMolleBagGorka">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34343,10 +31665,10 @@
         <value name="Tier1" />
     </type>
 	<type name="MassTacticalBag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34364,10 +31686,10 @@
         <value name="Tier1" />
     </type>
 	<type name="MassTacticalBagBlack">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34385,10 +31707,10 @@
         <value name="Tier1" />
     </type>
 	<type name="MassTacticalBagWD">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34493,7 +31815,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34513,7 +31835,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34533,7 +31855,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34553,7 +31875,7 @@
         <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>2</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34679,10 +32001,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSlingBag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34699,10 +32021,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSlingBagDesert">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -34719,10 +32041,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSlingBagGorka">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>1800</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -36772,10 +34094,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSurvivorBag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -36792,10 +34114,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSurvivorBag_Green">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -36814,10 +34136,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSurvivorBag_Black">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -36836,10 +34158,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSurvivorBag_Tan">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -36858,10 +34180,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassSurvivorBag_Winter">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>14400</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -37567,10 +34889,10 @@
         <value name="Tier2" />
     </type>
 	<type name="MassClothing_Bag">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>7200</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>10</quantmin>
         <quantmax>100</quantmax>
         <cost>50</cost>
@@ -40120,10 +37442,10 @@
         <value name="Tier1" />
   </type>
     <type name="Hikingbagmung_pink">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -40143,10 +37465,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_meow">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -40166,10 +37488,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_snow">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -40315,10 +37637,10 @@
         <value name="Tier1" />
   </type>
     <type name="bag_6B38_Snow_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -40469,10 +37791,10 @@
         <value name="Tier2" />
   </type>
 	<type name="bag_6B38_camo_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -40489,10 +37811,10 @@
         <value name="Tier2" />
   </type>
     <type name="bag_6B38_black_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -40509,10 +37831,10 @@
         <value name="Tier2" />
   </type>
 	<type name="bag_6B38_LETO_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41012,10 +38334,10 @@
         <value name="Tier2" />
   </type>
     <type name="fannypack_pink_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41033,10 +38355,10 @@
         <value name="Tier2" />
   </type>
 	<type name="fannypack_black_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41054,10 +38376,10 @@
         <value name="Tier2" />
   </type>
 	<type name="fannypack_camo_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41075,10 +38397,10 @@
         <value name="Tier2" />
   </type>
 	<type name="fannypack_multi_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41096,10 +38418,10 @@
         <value name="Tier2" />
   </type>
 	<type name="Hikingbagmung_white">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41119,10 +38441,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_yellow">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41142,10 +38464,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_red">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41165,10 +38487,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_blue">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41188,10 +38510,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_green">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41211,10 +38533,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_black">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41234,10 +38556,10 @@
         <value name="Tier2" />
   </type>
     <type name="Hikingbagmung_camo">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41582,10 +38904,10 @@
         <value name="Tier2" />
   </type>
     <type name="simplebackpack_blue_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41604,10 +38926,10 @@
         <value name="Tier2" />
   </type>
     <type name="simplebackpack_camoblack_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41626,10 +38948,10 @@
         <value name="Tier2" />
   </type>
     <type name="simplebackpack_green_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41648,10 +38970,10 @@
         <value name="Tier2" />
   </type>
     <type name="simplebackpack_redpink_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -41670,10 +38992,10 @@
         <value name="Tier2" />
   </type>
     <type name="simplebackpack_redyellow_mung">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -75119,10 +72441,10 @@
         <value name="Tier2" />
   </type>
     <type name="Canvas_Backpack_Base">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -75140,10 +72462,10 @@
         <value name="Tier2" />
   </type>
     <type name="Canvas_Backpack_Black">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -75161,10 +72483,10 @@
         <value name="Tier2" />
   </type>
     <type name="Canvas_Backpack_White">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -75182,10 +72504,10 @@
         <value name="Tier2" />
   </type>
     <type name="Canvas_Backpack_Red">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -75203,10 +72525,10 @@
         <value name="Tier2" />
   </type>
     <type name="Canvas_Backpack_Blue">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>
@@ -75224,10 +72546,10 @@
         <value name="Tier2" />
   </type>
     <type name="Canvas_Backpack_Purple">
-        <nominal>10</nominal>
+        <nominal>5</nominal>
         <lifetime>21600</lifetime>
         <restock>0</restock>
-        <min>5</min>
+        <min>3</min>
         <quantmin>-1</quantmin>
         <quantmax>-1</quantmax>
         <cost>50</cost>


### PR DESCRIPTION
Lowered all bags to 5 nominal 3 minimum and removed all the tiers from the items that we have spawning in all tiers to reduce the total line count.

Not sure why there is a conflict, I pulled the most recent file.